### PR TITLE
Search for Idendification criteria, after which always follows a comma

### DIFF
--- a/Virtual Librarian/Virtual Librarian/Utilities/StringUtils.cs
+++ b/Virtual Librarian/Virtual Librarian/Utilities/StringUtils.cs
@@ -12,7 +12,7 @@ namespace Virtual_Librarian
         /// </summary>
         public static string FromToNewline(this string value, string from)
         {
-            int posFrom = value.IndexOf(from);
+            int posFrom = value.IndexOf(from + ',');
             Regex newLineRegex = new Regex("(" + from + @".+?(?=\r\n))");
 
             //Check if not last entry


### PR DESCRIPTION
 To avoid finding Identification Criteria in other Fields (like Date)